### PR TITLE
feat: Add function Nil, NotNil

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Forked from [earthboundkid/be](https://github.com/earthboundkid/be), Inspired by
 ## Features
 
 - Simple and readable test assertions using generics
-- Built-in helpers for common cases like `test.NilErr` and `test.In`
+- Built-in helpers for common cases like `test.Nil` and `test.Contains`
 - Fail fast by default but easily switch to relaxed with `test.Relaxed(t)`
 - Helpers for testing against golden files with the testfile subpackage
 - No dependencies: just uses standard library
@@ -45,11 +45,11 @@ Handle errors:
 
 ```go
 var err error
-test.NilErr(t, err)   // good
+test.Nil(t, err)   // good
 test.NotZero(t, err) // bad
 // t.Fatal("got: <nil>")
 err = errors.New("(O_o)")
-test.NilErr(t, err)   // bad
+test.Nil(t, err)   // bad
 // t.Fatal("got: (O_o)")
 test.NotZero(t, err) // good
 ```

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Handle errors:
 ```go
 var err error
 test.Nil(t, err)   // good
-test.NotZero(t, err) // bad
+test.NotNil(t, err) // bad
 // t.Fatal("got: <nil>")
 err = errors.New("(O_o)")
 test.Nil(t, err)   // bad
 // t.Fatal("got: (O_o)")
-test.NotZero(t, err) // good
+test.NotNil(t, err) // good
 ```
 
 Check substring containment:

--- a/test.go
+++ b/test.go
@@ -66,8 +66,8 @@ func isZero[T any](v T) bool {
 	}
 }
 
-// NilErr calls t.Fatalf if err is not nil.
-func NilErr(t testing.TB, err error) {
+// Nil calls t.Fatalf if err is not nil.
+func Nil(t testing.TB, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("got: %v", err)

--- a/test.go
+++ b/test.go
@@ -74,6 +74,14 @@ func Nil(t testing.TB, v any) {
 	}
 }
 
+// NotNil calls t.Fatalf if v is nil.
+func NotNil(t testing.TB, v any) {
+	t.Helper()
+	if v == nil {
+		t.Fatalf("got: %v", v)
+	}
+}
+
 // True calls t.Fatalf if value is not true.
 func True(t testing.TB, value bool) {
 	t.Helper()

--- a/test.go
+++ b/test.go
@@ -66,11 +66,11 @@ func isZero[T any](v T) bool {
 	}
 }
 
-// Nil calls t.Fatalf if err is not nil.
-func Nil(t testing.TB, err error) {
+// Nil calls t.Fatalf if v is not nil.
+func Nil(t testing.TB, v any) {
 	t.Helper()
-	if err != nil {
-		t.Fatalf("got: %v", err)
+	if v != nil {
+		t.Fatalf("got: %v", v)
 	}
 }
 

--- a/test_example_test.go
+++ b/test_example_test.go
@@ -21,11 +21,11 @@ func Example() {
 	test.AllEqual(t, []int{3, 2, 1}, s) // bad
 
 	var err error
-	test.Nil(t, err)     // good
-	test.NotZero(t, err) // bad
+	test.Nil(t, err)    // good
+	test.NotNil(t, err) // bad
 	err = errors.New("(O_o)")
-	test.Nil(t, err)     // bad
-	test.NotZero(t, err) // good
+	test.Nil(t, err)    // bad
+	test.NotNil(t, err) // good
 
 	type mytype string
 	var mystring mytype = "hello, world"

--- a/test_example_test.go
+++ b/test_example_test.go
@@ -21,10 +21,10 @@ func Example() {
 	test.AllEqual(t, []int{3, 2, 1}, s) // bad
 
 	var err error
-	test.NilErr(t, err)  // good
+	test.Nil(t, err)     // good
 	test.NotZero(t, err) // bad
 	err = errors.New("(O_o)")
-	test.NilErr(t, err)  // bad
+	test.Nil(t, err)     // bad
 	test.NotZero(t, err) // good
 
 	type mytype string

--- a/test_test.go
+++ b/test_test.go
@@ -41,6 +41,7 @@ func Test(t *testing.T) {
 	beOkay(func(tb testing.TB) { test.Zero(tb, []string(nil)) })
 	beOkay(func(tb testing.TB) { test.NotZero(tb, []string{""}) })
 	beOkay(func(tb testing.TB) { test.Nil(tb, nil) })
+	beOkay(func(tb testing.TB) { test.NotNil(tb, errors.New("")) })
 	beOkay(func(tb testing.TB) { test.True(tb, true) })
 	beOkay(func(tb testing.TB) { test.False(tb, false) })
 	beBad := func(callback func(tb testing.TB)) {
@@ -60,6 +61,7 @@ func Test(t *testing.T) {
 	beBad(func(tb testing.TB) { test.Zero(tb, []string{""}) })
 	beBad(func(tb testing.TB) { test.NotZero(tb, []string(nil)) })
 	beBad(func(tb testing.TB) { test.Nil(tb, errors.New("")) })
+	beBad(func(tb testing.TB) { test.NotNil(tb, nil) })
 	beBad(func(tb testing.TB) { test.True(tb, false) })
 	beBad(func(tb testing.TB) { test.False(tb, true) })
 }

--- a/test_test.go
+++ b/test_test.go
@@ -40,7 +40,7 @@ func Test(t *testing.T) {
 	beOkay(func(tb testing.TB) { test.Zero(tb, time.Time{}.Local()) })
 	beOkay(func(tb testing.TB) { test.Zero(tb, []string(nil)) })
 	beOkay(func(tb testing.TB) { test.NotZero(tb, []string{""}) })
-	beOkay(func(tb testing.TB) { test.NilErr(tb, nil) })
+	beOkay(func(tb testing.TB) { test.Nil(tb, nil) })
 	beOkay(func(tb testing.TB) { test.True(tb, true) })
 	beOkay(func(tb testing.TB) { test.False(tb, false) })
 	beBad := func(callback func(tb testing.TB)) {
@@ -59,7 +59,7 @@ func Test(t *testing.T) {
 	beBad(func(tb testing.TB) { test.NotZero(tb, time.Time{}.Local()) })
 	beBad(func(tb testing.TB) { test.Zero(tb, []string{""}) })
 	beBad(func(tb testing.TB) { test.NotZero(tb, []string(nil)) })
-	beBad(func(tb testing.TB) { test.NilErr(tb, errors.New("")) })
+	beBad(func(tb testing.TB) { test.Nil(tb, errors.New("")) })
 	beBad(func(tb testing.TB) { test.True(tb, false) })
 	beBad(func(tb testing.TB) { test.False(tb, true) })
 }


### PR DESCRIPTION
- Rename NilErr to Nil
- Add NotNil 

## reason to change
- NilErr is only can be used with err type, but Nil is not
- NotNil has many usecases, although it is effectively same as NotZero on err type, after go 1.20